### PR TITLE
ns3-dce: Add return-statement to register_shrinker

### DIFF
--- a/arch/sim/vmscan.c
+++ b/arch/sim/vmscan.c
@@ -6,7 +6,7 @@
  */
 int register_shrinker(struct shrinker *shrinker)
 {
-
+	return 0;
 }
 
 /*


### PR DESCRIPTION
Otherwise, certain compiler will complain that the function returns void in a
function returning a non-void value.

Fixes: 1e9aa348d8b3 (adapt new API around v3.11-rc7)
Signed-off-by: Christoph Paasch christoph.paasch@uclouvain.be
